### PR TITLE
Added fix for lack of curve coloring when loading data into the gui.

### DIFF
--- a/qtui/Data.cpp
+++ b/qtui/Data.cpp
@@ -387,6 +387,7 @@ void Data::commit()
   } //end lock
   buildMeasurementsIndex_();
   buildCurveIndex_();
+  updateIdentity_();
   emit loaded();
 }
 
@@ -550,6 +551,32 @@ void Data::buildMeasurementsIndex_()
       maxIdent_ = qMax(maxIdent_,(int)m->state);
     }
   }
+}
+
+// Bugfix, 05.11.2014, Author: Viktor Bahr (viktor@bccn-berlin.de)
+// Initialize state with id to overcome color display issue with loaded data 
+void Data::updateIdentity_()
+{
+	LOCK;
+	if(measurements_)
+	{
+		TRY(maybeShowFaceAnchorRequiredDialog());
+		for(Measurements *m=measurements_;m<measurements_+nmeasurements_;++m)
+		{
+			setIdentity(m->fid, m->wid, m->wid);
+		}
+	}
+	else if(curves_)
+	{
+		TRY(maybeShowFaceAnchorRequiredDialog());
+		for(Whisker_Seg *c=curves_;c<curves_+ncurves_;++c)
+		{
+			setIdentity(c->time, c->id, c->id);
+		}
+	}
+
+Error:
+	return;
 }
 
 bool Data::isFaceSet()

--- a/qtui/Data.h
+++ b/qtui/Data.h
@@ -124,4 +124,5 @@ class Data : public QObject
 
     void buildCurveIndex_();
     void buildMeasurementsIndex_();
+	void updateIdentity_();
 };


### PR DESCRIPTION
Hi Nathan,

here's a quick survey of the issue itself and what I did to fix it.

**THE ISSUE:**
When loading whisker or measurement files already tracked manually, the data is loaded correctly but no identity is set. Hence whiskers have a red color and are highlighted only when selecting whisker ID -1. The user is unable to continue tracking / correct errors on videos with more than one whisker.

**THE FIX:**
I used the `setIdenity()` function to initially set the idenity for loaded whiskers and measurements; see `updateIdentity_()` .

Take care, best regards,
Viktor
