### PR TITLE
removing inline everywhere

### DIFF
--- a/include/bar_io.h
+++ b/include/bar_io.h
@@ -16,7 +16,7 @@ typedef struct _Bar
   float y;
 } Bar;
 
-inline Bar *Bar_Static_Cast( int time, float x, float y);
+ Bar *Bar_Static_Cast( int time, float x, float y);
 
 void        Bar_Sort_By_Time( Bar *bars, int nbars);
 

--- a/include/compat.h
+++ b/include/compat.h
@@ -29,14 +29,14 @@ typedef unsigned long long uint64_t;
 #define log2(x) (log(x)/log(2))       // there are fast tricks for finding int(log2(x))
 #endif                             
 
-#define inline //_inline
+#define  //_inline
 #define msvcextern extern
 
 #define hypotf _hypotf
 
-inline long int lround(float x);
-inline double round(double x);
-inline float roundf(float x);
+ long int lround(float x);
+ double round(double x);
+ float roundf(float x);
 
 #define isnan _isnan
 

--- a/include/deque.h
+++ b/include/deque.h
@@ -29,16 +29,16 @@ typedef struct _Deque
   size_t size_bytes;
 } Deque;
 
-SHARED_EXPORT inline  Deque *Deque_Alloc      ( int size_hint );
-SHARED_EXPORT inline  void   Deque_Free       ( Deque *self );
-SHARED_EXPORT inline  void   Deque_Reset      ( Deque *self );
-SHARED_EXPORT inline  void   Deque_Squeeze    ( Deque *self );
-SHARED_EXPORT inline  void  *Deque_Front      ( Deque *self);
-SHARED_EXPORT inline  int    Deque_Is_Empty   ( Deque *self);
-SHARED_EXPORT inline  void  *Deque_Back       ( Deque *self);
-SHARED_EXPORT inline  Deque *Deque_Push_Front ( Deque *self, void *item );
-SHARED_EXPORT inline  void  *Deque_Pop_Front  ( Deque *self );
-SHARED_EXPORT inline  Deque *Deque_Push_Back  ( Deque *self, void *item );
-SHARED_EXPORT inline  void  *Deque_Pop_Back   ( Deque *self );
+SHARED_EXPORT   Deque *Deque_Alloc      ( int size_hint );
+SHARED_EXPORT   void   Deque_Free       ( Deque *self );
+SHARED_EXPORT   void   Deque_Reset      ( Deque *self );
+SHARED_EXPORT   void   Deque_Squeeze    ( Deque *self );
+SHARED_EXPORT   void  *Deque_Front      ( Deque *self);
+SHARED_EXPORT   int    Deque_Is_Empty   ( Deque *self);
+SHARED_EXPORT   void  *Deque_Back       ( Deque *self);
+SHARED_EXPORT   Deque *Deque_Push_Front ( Deque *self, void *item );
+SHARED_EXPORT   void  *Deque_Pop_Front  ( Deque *self );
+SHARED_EXPORT   Deque *Deque_Push_Back  ( Deque *self, void *item );
+SHARED_EXPORT   void  *Deque_Pop_Back   ( Deque *self );
 
 #endif

--- a/include/eval.h
+++ b/include/eval.h
@@ -44,7 +44,7 @@ void Render_Line_Detector( float offset,
                            point anchor,
                            float *image, int *strides  );
 
-inline float *Get_Line_Detector( Array *bank, int iangle, int iwidth, int ioffset );
+ float *Get_Line_Detector( Array *bank, int iangle, int iwidth, int ioffset );
 Array *Build_Line_Detectors( Range off, Range ang, Range wid, float length, int supportsize );
 Array *Build_Curved_Line_Detectors( Range off, 
                                     Range wid, 
@@ -59,6 +59,6 @@ Array *Build_Harmonic_Line_Detectors( Range off,
                                       float length, 
                                       int supportsize );
 
-inline float *Get_Half_Space_Detector( Array *bank, int iangle, int iwidth, int ioffset );
+ float *Get_Half_Space_Detector( Array *bank, int iangle, int iwidth, int ioffset );
 Array *Build_Half_Space_Detectors( Range off, Range ang, Range wid, float length, int supportsize );
 #endif // H_EVAL

--- a/include/ffmpeg_adapt.h
+++ b/include/ffmpeg_adapt.h
@@ -37,7 +37,7 @@
 #ifdef HAVE_FFMPEG
 
 #ifdef _MSC_VER
-#define inline _inline
+#define  _inline
 #endif
 
 //#include <libavcodec/avcodec.h>

--- a/include/image_lib.h
+++ b/include/image_lib.h
@@ -71,7 +71,7 @@ typedef struct _Image
 #define IMAGE_PIXEL_32(img,x,y,c) \
       ((float32 *) ((img)->array + (((y)*(img)->width + (x))*(img)->kind + (c))))
 
-static inline double Get_Image_Pixel(Image *image, int x, int y, int c)
+static  double Get_Image_Pixel(Image *image, int x, int y, int c)
 { if (image->kind == GREY16)
     return (*IMAGE_PIXEL_16(image,x,y,c));
   else if (image->kind == FLOAT32)
@@ -80,7 +80,7 @@ static inline double Get_Image_Pixel(Image *image, int x, int y, int c)
     return (*IMAGE_PIXEL_8(image,x,y,c));
 }
 
-static inline void Set_Image_Pixel(Image *image, int x, int y, int c, double v)
+static  void Set_Image_Pixel(Image *image, int x, int y, int c, double v)
 { if (image->kind == GREY16)
     *IMAGE_PIXEL_16(image,x,y,c) = (uint16)v;
   else if (image->kind == FLOAT32)
@@ -154,7 +154,7 @@ typedef struct _Stack
       ((float32 *) ((img)->array +   \
            ((((z)*(img)->height + (y))*(img)->width + (x))*(img)->kind + (c))))
 
-static inline double Get_Stack_Pixel(Stack *stack, int x, int y, int z, int c)
+static  double Get_Stack_Pixel(Stack *stack, int x, int y, int z, int c)
 { if (stack->kind == GREY16)
     return (*STACK_PIXEL_16(stack,x,y,z,c));
   else if (stack->kind == FLOAT32)
@@ -163,7 +163,7 @@ static inline double Get_Stack_Pixel(Stack *stack, int x, int y, int z, int c)
     return (*STACK_PIXEL_8(stack,x,y,z,c));
 }
 
-static inline void Set_Stack_Pixel(Stack *stack, int x, int y, int z, int c, double v)
+static  void Set_Stack_Pixel(Stack *stack, int x, int y, int z, int c, double v)
 { if (stack->kind == GREY16)
     *STACK_PIXEL_16(stack,x,y,z,c) = (uint16)v;
   else if (stack->kind == FLOAT32)

--- a/include/poly.h
+++ b/include/poly.h
@@ -18,20 +18,20 @@
 //
 #include "compat.h"
 
-inline double polyval             ( double *p, int degree, double x);
-inline int    polymul_nelem_dest  ( int na, int nb);
-inline void   polymul             ( double *a, int na, double *b, int nb, double *dest );
-inline void   polyadd_ip_left     ( double *a, int na, double *b, int nb );
-inline void   polysub_ip_left     ( double *a, int na, double *b, int nb );
-inline void   polyadd             ( double *a, int na, double *b, int nb, double *dest );
-inline void   polysub             ( double *a, int na, double *b, int nb, double *dest );
-inline void   polyder_ip          ( double *a, int na, int times);
+ double polyval             ( double *p, int degree, double x);
+ int    polymul_nelem_dest  ( int na, int nb);
+ void   polymul             ( double *a, int na, double *b, int nb, double *dest );
+ void   polyadd_ip_left     ( double *a, int na, double *b, int nb );
+ void   polysub_ip_left     ( double *a, int na, double *b, int nb );
+ void   polyadd             ( double *a, int na, double *b, int nb, double *dest );
+ void   polysub             ( double *a, int na, double *b, int nb, double *dest );
+ void   polyder_ip          ( double *a, int na, int times);
 
 void    Vandermonde_Build             ( double *x, int n, int degree, double *V );
 void    Vandermonde_Inverse           ( double *x, int n, double *invV);
 double  Vandermonde_Determinant       ( double *x, int n );
 double  Vandermonde_Determinant_Log2  ( double *x, int n );
-inline int polyfit_size_workspace     ( int n, int degree );
+ int polyfit_size_workspace     ( int n, int degree );
 double *polyfit_alloc_workspace       ( int n, int degree );
 void    polyfit_realloc_workspace     ( int n, int degree, double **workspace );
 void    polyfit_free_workspace        ( double *workspace );

--- a/include/svd.h
+++ b/include/svd.h
@@ -8,9 +8,9 @@
  */
 #ifndef H_SVD
 
-inline void svd_threshold ( double thresh, double *w, int n );
+ void svd_threshold ( double thresh, double *w, int n );
 
-inline void svd_backsub   ( double *u, double *w, double *v, 
+ void svd_backsub   ( double *u, double *w, double *v, 
                             int nrows, int ncols, 
                             double *b, double *x );
 

--- a/src/aip.c
+++ b/src/aip.c
@@ -40,11 +40,11 @@
 #include "aip.h"
 #include <stdlib.h>
 
-inline void bdr(real * X, real y)
+ void bdr(real * X, real y)
 { *X = *X<y ? *X:y;
 }
 
-inline void bur(real * X, real y)
+ void bur(real * X, real y)
 { *X = *X>y ? *X:y;
 }
 
@@ -95,20 +95,20 @@ double fit(box *B, point * x, int cx, vertex * ix, int fudge)
   return sclx*scly;
 }
 
-inline hp area(ipoint a, ipoint p, ipoint q)
+ hp area(ipoint a, ipoint p, ipoint q)
 /* Compute the area of the triangle (apq) */
 { return (hp)p.x*q.y - (hp)p.y*q.x +
     (hp)a.x*(p.y - q.y) + (hp)a.y*(q.x - p.x);
 }
 
-inline void cntrib(hp *s, ipoint f, ipoint t, short w)
+ void cntrib(hp *s, ipoint f, ipoint t, short w)
 /* Integrand for the line integral.  Google `Green's theorem polygon area` for
  * functional form.
  */
 { *s += (hp)w*(t.x-f.x)*(t.y+f.y)/2;
 }
 
-inline int ovl(rng p, rng q)
+ int ovl(rng p, rng q)
 /* True if intervals intersect */
 { return p.mn < q.mx && q.mn < p.mx;
 }

--- a/src/bar_io.c
+++ b/src/bar_io.c
@@ -25,7 +25,7 @@ typedef struct _Bar
   float y;
 } Bar;
 
-inline Bar *Bar_Static_Cast( int time, float x, float y)
+ Bar *Bar_Static_Cast( int time, float x, float y)
 { static Bar b;
   b.time = time;
   b.x = x;

--- a/src/classify.c
+++ b/src/classify.c
@@ -93,7 +93,7 @@ void Helper_Get_Follicle_Const_Axis( char* directive, int maxx, int maxy, int* c
   }
 }
 
-inline void Measurements_Table_Label_By_RadialThreshold( Measurements *table, int n_rows, double thresh, int ox, int oy, int colx, int coly)
+ void Measurements_Table_Label_By_RadialThreshold( Measurements *table, int n_rows, double thresh, int ox, int oy, int colx, int coly)
 {
   double t2 = thresh*thresh;
   Measurements *row = table + n_rows;
@@ -110,7 +110,7 @@ inline void Measurements_Table_Label_By_RadialThreshold( Measurements *table, in
   }
 } 
 
-inline void Measurements_Table_Label_By_Threshold( Measurements *table, int n_rows, int col, double threshold, int is_gt )
+ void Measurements_Table_Label_By_Threshold( Measurements *table, int n_rows, int col, double threshold, int is_gt )
 { Measurements *row = table + n_rows;
   if(is_gt)
   { while(row-- > table)
@@ -121,7 +121,7 @@ inline void Measurements_Table_Label_By_Threshold( Measurements *table, int n_ro
   }
 }
 
-inline void Measurements_Table_Label_By_Threshold_Or( Measurements *table, int n_rows, int col, double threshold, int is_gt )
+ void Measurements_Table_Label_By_Threshold_Or( Measurements *table, int n_rows, int col, double threshold, int is_gt )
 { Measurements *row = table + n_rows;
   if(is_gt)
   { while(row-- > table)
@@ -132,7 +132,7 @@ inline void Measurements_Table_Label_By_Threshold_Or( Measurements *table, int n
   }
 }
 
-inline void Measurements_Table_Label_By_Threshold_And( Measurements *table, int n_rows, int col, double threshold, int is_gt )
+ void Measurements_Table_Label_By_Threshold_And( Measurements *table, int n_rows, int col, double threshold, int is_gt )
 { Measurements *row = table + n_rows;
   if(is_gt)
   { while(row-- > table)
@@ -683,7 +683,7 @@ int main(int argc, char* argv[])
   // Follicle location threshold
   if( Is_Arg_Matched("--follicle") && Get_Int_Arg("--follicle")>0 )
     follicle_thresh = Get_Int_Arg("--follicle");
-    //inline void Measurements_Table_Label_By_RadialThreshold( Measurements *table, int n_rows, double thresh, int ox, int oy, int colx, int coly)
+    // void Measurements_Table_Label_By_RadialThreshold( Measurements *table, int n_rows, double thresh, int ox, int oy, int colx, int coly)
   Measurements_Table_Label_By_RadialThreshold( table,
                                                n_rows,
                                                follicle_thresh,

--- a/src/common.c
+++ b/src/common.c
@@ -55,7 +55,7 @@ void *request_storage_zeroed( void *buffer, size_t *maxlen, size_t nbytes, size_
   return buffer;
 }
 
-inline size_t _next_pow2_uint32(uint32_t v)
+ size_t _next_pow2_uint32(uint32_t v)
 { v--;
   v |= v >> 1;
   v |= v >> 2;
@@ -66,7 +66,7 @@ inline size_t _next_pow2_uint32(uint32_t v)
   return v;
 }
 
-inline size_t _next_pow2_uint64(uint64_t v)
+ size_t _next_pow2_uint64(uint64_t v)
 { v--;
   v |= v >> 1;
   v |= v >> 2;

--- a/src/compat.c
+++ b/src/compat.c
@@ -12,17 +12,17 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-extern inline long int lround(float x)
+extern  long int lround(float x)
 {
 return (long)(x < 0 ? -floor(fabs(x) + .5) : floor(x + .5));
 }
 
-extern inline double round(double x)
+extern  double round(double x)
 {
   return x < 0 ? -floor(fabs(x) + .5) : floor(x + .5);
 }
 
-extern inline float roundf(float x)
+extern  float roundf(float x)
 {
   return x < 0 ? -floorf(fabsf(x) + .5) : floorf(x + .5);
 }

--- a/src/contour_lib.p
+++ b/src/contour_lib.p
@@ -23,7 +23,7 @@ static int     Carea;
 static uint8  *Value8;
 static uint16 *Value16;
 
-static inline int contour_tsize(Contour *contour)
+static  int contour_tsize(Contour *contour)
 { return (sizeof(int) * contour->length); }
 
 MANAGER -r Contour tour:tsize
@@ -38,7 +38,7 @@ void Reset_Contour()
    'cmprsn' the comparator for membership in the region.
 */
 
-static inline int legal_move(int p, int d)
+static  int legal_move(int p, int d)
 { switch (d)
   { case 0:
       return (p+Cwidth < Carea);
@@ -53,26 +53,26 @@ static inline int legal_move(int p, int d)
   }
 }
 
-static inline int boundary_pixel(int p)
+static  int boundary_pixel(int p)
 { int q = p % Cwidth;
   return (p < Cwidth || p+Cwidth >= Carea || q == 0 || q+1 == Cwidth);
 }
 
-static inline int is_le(int p, int level)
+static  int is_le(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] <= level);
   else
     return (Value16[p] <= level);
 }
 
-static inline int is_ge(int p, int level)
+static  int is_ge(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] >= level);
   else
     return (Value16[p] >= level);
 }
 
-static inline int is_eq(int p, int level)
+static  int is_eq(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] == level);
   else

--- a/src/deque.c
+++ b/src/deque.c
@@ -54,7 +54,7 @@ void Deque_Free(Deque *self)
 }
 
 SHARED_EXPORT 
-inline void Deque_Reset ( Deque *self )
+ void Deque_Reset ( Deque *self )
 { int n = self->size_bytes/sizeof(void*)/2;
   memset( self->store, 0, self->size_bytes );
   self->front = n-1;
@@ -74,28 +74,28 @@ void Deque_Squeeze(Deque *self)
 }
 
 SHARED_EXPORT
-inline void *Deque_Front(Deque *self)
+ void *Deque_Front(Deque *self)
 { return self->store[self->front];
 }
 
 SHARED_EXPORT
-inline void *Deque_Back(Deque *self)
+ void *Deque_Back(Deque *self)
 { return self->store[self->back];
 }
 
 SHARED_EXPORT
-inline int  Deque_Is_Empty(Deque *self)
+ int  Deque_Is_Empty(Deque *self)
 { return (self->front == self->back - 1);
 }
 
 SHARED_EXPORT
-inline Deque *_Deque_Push_Front_Unsafe( Deque* self, void *item )
+ Deque *_Deque_Push_Front_Unsafe( Deque* self, void *item )
 { self->store[++self->front] = item;
   return self;
 }
 
 SHARED_EXPORT
-inline Deque *Deque_Push_Front( Deque* self, void *item )
+ Deque *Deque_Push_Front( Deque* self, void *item )
 { size_t s = self->size_bytes/sizeof(void*);
   if( self->front >= s - 2 )
     self->store = request_storage( self->store, &self->size_bytes, sizeof(void*), s+1, "Deque: realloc on push front" );
@@ -103,12 +103,12 @@ inline Deque *Deque_Push_Front( Deque* self, void *item )
 }
 
 SHARED_EXPORT
-inline void *_Deque_Pop_Front_Unsafe( Deque* self)
+ void *_Deque_Pop_Front_Unsafe( Deque* self)
 { return self->store[self->front--];
 }
 
 SHARED_EXPORT
-inline void *Deque_Pop_Front( Deque *self )
+ void *Deque_Pop_Front( Deque *self )
 { if( self->front >= self->back )
     return _Deque_Pop_Front_Unsafe(self);
 #ifdef WARNING_POP_FROM_EMPTY
@@ -119,13 +119,13 @@ inline void *Deque_Pop_Front( Deque *self )
 }
 
 SHARED_EXPORT
-inline Deque *_Deque_Push_Back_Unsafe( Deque* self, void *item )
+ Deque *_Deque_Push_Back_Unsafe( Deque* self, void *item )
 { self->store[--self->back] = item;
   return self;
 }
 
 SHARED_EXPORT
-inline Deque *Deque_Push_Back( Deque *self, void *item )
+ Deque *Deque_Push_Back( Deque *self, void *item )
 { if( self->back <= 1 )  // then, need to move things
   { size_t f = self->front,
            b = self->back,
@@ -147,12 +147,12 @@ inline Deque *Deque_Push_Back( Deque *self, void *item )
 }
 
 SHARED_EXPORT
-inline void *_Deque_Pop_Back_Unsafe( Deque* self)
+ void *_Deque_Pop_Back_Unsafe( Deque* self)
 { return self->store[self->back++];
 }
 
 SHARED_EXPORT
-inline void *Deque_Pop_Back( Deque *self )
+ void *Deque_Pop_Back( Deque *self )
 { if( self->front >= self->back )
     return _Deque_Pop_Back_Unsafe(self);
 #ifdef WARNING_POP_FROM_EMPTY

--- a/src/eval.c
+++ b/src/eval.c
@@ -150,7 +150,7 @@ void Free_Array( Array *a)
   free(a);
 }
 
-inline void pixel_to_vertex_array(int p, int stride, float *v)
+ void pixel_to_vertex_array(int p, int stride, float *v)
 { float x = p%stride;
   float y = p/stride;
   v[0] = x;      v[1] = y;
@@ -160,7 +160,7 @@ inline void pixel_to_vertex_array(int p, int stride, float *v)
   return;
 }
 
-inline unsigned array_max_f32u ( float *buf, int size, int step, float bound )
+ unsigned array_max_f32u ( float *buf, int size, int step, float bound )
 { float *t = buf + size;
   float r = 0.0;       
   while( (t -= step) >= buf )
@@ -168,7 +168,7 @@ inline unsigned array_max_f32u ( float *buf, int size, int step, float bound )
   return (unsigned) MIN(r,bound);
 }
 
-inline unsigned array_min_f32u ( float *buf, int size, int step, float bound )
+ unsigned array_min_f32u ( float *buf, int size, int step, float bound )
 { float *t = buf + size;
   float r = FLT_MAX;
   while( (t -= step) >= buf )
@@ -351,7 +351,7 @@ void Multiply_Gaussian_Along_Direction( float x0, float y0, float vx, float vy, 
 }
 
 /* Anchor is in the center */
-inline void Simple_Line_Primitive( point *verts, point offset, float length, float thick )
+ void Simple_Line_Primitive( point *verts, point offset, float length, float thick )
 { point v0 = { offset.x - length,  offset.y - thick},
         v1 = { offset.x + length,  offset.y - thick},
         v2 = { offset.x + length,  offset.y + thick},
@@ -616,11 +616,11 @@ void Render_Line_Detector_v0( float offset,
   return;
 }
 
-inline int compute_number_steps( Range *r )
+ int compute_number_steps( Range *r )
 {  return lround( (r->max - r->min) / r->step ) + 1;
 }
 
-inline float *Get_Line_Detector( Array *bank, int ioffset, int iwidth, int iangle  )
+ float *Get_Line_Detector( Array *bank, int ioffset, int iwidth, int iangle  )
 { return ((float*) (bank->data)) + iangle  * bank->strides_px[1] 
                                  + iwidth  * bank->strides_px[2] 
                                  + ioffset * bank->strides_px[3]; 
@@ -792,7 +792,7 @@ void Render_Half_Space_Detector( float offset,
   return;
 }
 
-inline float *Get_Half_Space_Detector( Array *bank, int ioffset, int iwidth, int iangle  )
+ float *Get_Half_Space_Detector( Array *bank, int ioffset, int iwidth, int iangle  )
 { return ((float*) (bank->data)) + iangle  * bank->strides_px[1] 
                                  + iwidth  * bank->strides_px[2] 
                                  + ioffset * bank->strides_px[3]; 

--- a/src/evaltest.c
+++ b/src/evaltest.c
@@ -66,7 +66,7 @@ void hsv2rgb( hsv *im, rgb *r    )
   return;
 }
 
-inline void blend_rgb_ip( rgb *im, rgb *b, float a )
+ void blend_rgb_ip( rgb *im, rgb *b, float a )
 { im->r = (uint8)( (im->r * (1.0-a)) + b->r * a );
   im->g = (uint8)( (im->g * (1.0-a)) + b->g * a );
   im->b = (uint8)( (im->b * (1.0-a)) + b->b * a );

--- a/src/generated/contour_lib.c
+++ b/src/generated/contour_lib.c
@@ -23,7 +23,7 @@ static int     Carea;
 static uint8  *Value8;
 static uint16 *Value16;
 
-static inline int contour_tsize(Contour *contour)
+static  int contour_tsize(Contour *contour)
 { return (sizeof(int) * contour->length); }
 
 
@@ -36,7 +36,7 @@ typedef struct __Contour
 static _Contour *Free_Contour_List = NULL;
 static int    Contour_Offset, Contour_Inuse;
 
-static inline void allocate_contour_tour(Contour *contour, int tsize, char *routine)
+static  void allocate_contour_tour(Contour *contour, int tsize, char *routine)
 { _Contour *object  = (_Contour *) (((char *) contour) - Contour_Offset);
   if (object->tsize < tsize)
     { object->contour.tour  = Guarded_Realloc(object->contour.tour,tsize,routine);
@@ -44,7 +44,7 @@ static inline void allocate_contour_tour(Contour *contour, int tsize, char *rout
     }
 }
 
-static inline Contour *new_contour(int tsize, char *routine)
+static  Contour *new_contour(int tsize, char *routine)
 { _Contour *object;
 
   if (Free_Contour_List == NULL)
@@ -62,7 +62,7 @@ static inline Contour *new_contour(int tsize, char *routine)
   return (&(object->contour));
 }
 
-static inline Contour *copy_contour(Contour *contour)
+static  Contour *copy_contour(Contour *contour)
 { _Contour *object  = (_Contour *) (((char *) contour) - Contour_Offset);
   Contour *copy = new_contour(contour_tsize(contour),"Copy_Contour");
   Contour  temp = *copy;
@@ -76,7 +76,7 @@ static inline Contour *copy_contour(Contour *contour)
 Contour *Copy_Contour(Contour *contour)
 { return (copy_contour(contour)); }
 
-static inline void pack_contour(Contour *contour)
+static  void pack_contour(Contour *contour)
 { _Contour *object  = (_Contour *) (((char *) contour) - Contour_Offset);
   if (object->tsize > contour_tsize(contour))
     { object->tsize = contour_tsize(contour);
@@ -91,7 +91,7 @@ static inline void pack_contour(Contour *contour)
 void Pack_Contour(Contour *contour)
 { pack_contour(contour); }
 
-static inline void free_contour(Contour *contour)
+static  void free_contour(Contour *contour)
 { _Contour *object  = (_Contour *) (((char *) contour) - Contour_Offset);
   object->next = Free_Contour_List;
   Free_Contour_List = object;
@@ -101,7 +101,7 @@ static inline void free_contour(Contour *contour)
 void Free_Contour(Contour *contour)
 { free_contour(contour); }
 
-static inline void kill_contour(Contour *contour)
+static  void kill_contour(Contour *contour)
 { _Contour *object  = (_Contour *) (((char *) contour) - Contour_Offset);
   if (contour->tour != NULL)
     free(contour->tour);
@@ -112,7 +112,7 @@ static inline void kill_contour(Contour *contour)
 void Kill_Contour(Contour *contour)
 { kill_contour(contour); }
 
-static inline void reset_contour()
+static  void reset_contour()
 { _Contour *object;
   while (Free_Contour_List != NULL)
     { object = Free_Contour_List;
@@ -135,7 +135,7 @@ void Reset_Contour()
    'cmprsn' the comparator for membership in the region.
 */
 
-static inline int legal_move(int p, int d)
+static  int legal_move(int p, int d)
 { switch (d)
   { case 0:
       return (p+Cwidth < Carea);
@@ -150,26 +150,26 @@ static inline int legal_move(int p, int d)
   }
 }
 
-static inline int boundary_pixel(int p)
+static  int boundary_pixel(int p)
 { int q = p % Cwidth;
   return (p < Cwidth || p+Cwidth >= Carea || q == 0 || q+1 == Cwidth);
 }
 
-static inline int is_le(int p, int level)
+static  int is_le(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] <= level);
   else
     return (Value16[p] <= level);
 }
 
-static inline int is_ge(int p, int level)
+static  int is_ge(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] >= level);
   else
     return (Value16[p] >= level);
 }
 
-static inline int is_eq(int p, int level)
+static  int is_eq(int p, int level)
 { if (Value8 != NULL)
     return (Value8[p] == level);
   else

--- a/src/generated/image_lib.c
+++ b/src/generated/image_lib.c
@@ -76,10 +76,10 @@ static uint32 *get_raster(int npixels, char *routine)
 
 // Awk-generated (manager.awk) Image memory management
 
-static inline int image_asize(Image *image)
+static  int image_asize(Image *image)
 { return (image->height*image->width*image->kind); }
 
-static inline int image_tsize(Image *image)
+static  int image_tsize(Image *image)
 { return (strlen(image->text)+1); }
 
 
@@ -93,7 +93,7 @@ typedef struct __Image
 static _Image *Free_Image_List = NULL;
 static int    Image_Offset, Image_Inuse;
 
-static inline void allocate_image_array(Image *image, int asize, char *routine)
+static  void allocate_image_array(Image *image, int asize, char *routine)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   if (object->asize < asize)
     { object->image.array  = Guarded_Realloc(object->image.array,asize,routine);
@@ -101,7 +101,7 @@ static inline void allocate_image_array(Image *image, int asize, char *routine)
     }
 }
 
-static inline void allocate_image_text(Image *image, int tsize, char *routine)
+static  void allocate_image_text(Image *image, int tsize, char *routine)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   if (object->tsize < tsize)
     { object->image.text  = Guarded_Realloc(object->image.text,tsize,routine);
@@ -109,7 +109,7 @@ static inline void allocate_image_text(Image *image, int tsize, char *routine)
     }
 }
 
-static inline Image *new_image(int asize, int tsize, char *routine)
+static  Image *new_image(int asize, int tsize, char *routine)
 { _Image *object;
 
   if (Free_Image_List == NULL)
@@ -130,7 +130,7 @@ static inline Image *new_image(int asize, int tsize, char *routine)
   return (&(object->image));
 }
 
-static inline Image *copy_image(Image *image)
+static  Image *copy_image(Image *image)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   Image *copy = new_image(image_asize(image),image_tsize(image),"Copy_Image");
   Image  temp = *copy;
@@ -147,7 +147,7 @@ static inline Image *copy_image(Image *image)
 Image *Copy_Image(Image *image)
 { return (copy_image(image)); }
 
-static inline void pack_image(Image *image)
+static  void pack_image(Image *image)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   if (object->asize > image_asize(image))
     { object->asize = image_asize(image);
@@ -170,7 +170,7 @@ static inline void pack_image(Image *image)
 void Pack_Image(Image *image)
 { pack_image(image); }
 
-static inline void free_image(Image *image)
+static  void free_image(Image *image)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   object->next = Free_Image_List;
   Free_Image_List = object;
@@ -180,7 +180,7 @@ static inline void free_image(Image *image)
 void Free_Image(Image *image)
 { free_image(image); }
 
-static inline void kill_image(Image *image)
+static  void kill_image(Image *image)
 { _Image *object  = (_Image *) (((char *) image) - Image_Offset);
   if (image->text != NULL)
     free(image->text);
@@ -193,7 +193,7 @@ static inline void kill_image(Image *image)
 void Kill_Image(Image *image)
 { kill_image(image); }
 
-static inline void reset_image()
+static  void reset_image()
 { _Image *object;
   while (Free_Image_List != NULL)
     { object = Free_Image_List;
@@ -213,10 +213,10 @@ void Reset_Image()
 
 // Awk-generated (manager.awk) Stack memory management
 
-static inline int stack_vsize(Stack *stack)
+static  int stack_vsize(Stack *stack)
 { return (stack->depth*stack->height*stack->width*stack->kind); }
 
-static inline int stack_tsize(Stack *stack)
+static  int stack_tsize(Stack *stack)
 { return (strlen(stack->text)+1); }
 
 
@@ -230,7 +230,7 @@ typedef struct __Stack
 static _Stack *Free_Stack_List = NULL;
 static int    Stack_Offset, Stack_Inuse;
 
-static inline void allocate_stack_array(Stack *stack, int vsize, char *routine)
+static  void allocate_stack_array(Stack *stack, int vsize, char *routine)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   if (object->vsize < vsize)
     { object->stack.array  = Guarded_Realloc(object->stack.array,vsize,routine);
@@ -238,7 +238,7 @@ static inline void allocate_stack_array(Stack *stack, int vsize, char *routine)
     }
 }
 
-static inline void allocate_stack_text(Stack *stack, int tsize, char *routine)
+static  void allocate_stack_text(Stack *stack, int tsize, char *routine)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   if (object->tsize < tsize)
     { object->stack.text  = Guarded_Realloc(object->stack.text,tsize,routine);
@@ -246,7 +246,7 @@ static inline void allocate_stack_text(Stack *stack, int tsize, char *routine)
     }
 }
 
-static inline Stack *new_stack(int vsize, int tsize, char *routine)
+static  Stack *new_stack(int vsize, int tsize, char *routine)
 { _Stack *object;
 
   if (Free_Stack_List == NULL)
@@ -267,7 +267,7 @@ static inline Stack *new_stack(int vsize, int tsize, char *routine)
   return (&(object->stack));
 }
 
-static inline Stack *copy_stack(Stack *stack)
+static  Stack *copy_stack(Stack *stack)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   Stack *copy = new_stack(stack_vsize(stack),stack_tsize(stack),"Copy_Stack");
   Stack  temp = *copy;
@@ -284,7 +284,7 @@ static inline Stack *copy_stack(Stack *stack)
 Stack *Copy_Stack(Stack *stack)
 { return (copy_stack(stack)); }
 
-static inline void pack_stack(Stack *stack)
+static  void pack_stack(Stack *stack)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   if (object->vsize > stack_vsize(stack))
     { object->vsize = stack_vsize(stack);
@@ -307,7 +307,7 @@ static inline void pack_stack(Stack *stack)
 void Pack_Stack(Stack *stack)
 { pack_stack(stack); }
 
-static inline void free_stack(Stack *stack)
+static  void free_stack(Stack *stack)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   object->next = Free_Stack_List;
   Free_Stack_List = object;
@@ -317,7 +317,7 @@ static inline void free_stack(Stack *stack)
 void Free_Stack(Stack *stack)
 { free_stack(stack); }
 
-static inline void kill_stack(Stack *stack)
+static  void kill_stack(Stack *stack)
 { _Stack *object  = (_Stack *) (((char *) stack) - Stack_Offset);
   if (stack->text != NULL)
     free(stack->text);
@@ -330,7 +330,7 @@ static inline void kill_stack(Stack *stack)
 void Kill_Stack(Stack *stack)
 { kill_stack(stack); }
 
-static inline void reset_stack()
+static  void reset_stack()
 { _Stack *object;
   while (Free_Stack_List != NULL)
     { object = Free_Stack_List;

--- a/src/generated/level_set.c
+++ b/src/generated/level_set.c
@@ -125,14 +125,14 @@ int Get_Component_Tree_Connectivity(Component_Tree *atree)
  *                                                                                      *
  ****************************************************************************************/
 
-static inline int size(int cont)
+static  int size(int cont)
 { if (cont > 0)
     return (regtrees[cont].size);
   else
     return (1);
 }
 
-static inline int level(int cont)
+static  int level(int cont)
 { if (cont > 0)
     return (regtrees[cont].level);
   else if (value8 != NULL)
@@ -141,7 +141,7 @@ static inline int level(int cont)
     return (value16[-cont]);
 }
 
-static inline int peak(int cont)
+static  int peak(int cont)
 { if (cont > 0)
     return (regtrees[cont].peak);
   else if (value8 != NULL)
@@ -150,14 +150,14 @@ static inline int peak(int cont)
     return (value16[-cont]);
 }
 
-static inline int start(int cont)
+static  int start(int cont)
 { if (cont > 0)
     return (regtrees[cont].start);
   else
     return (-cont);
 }
 
-inline Level_Set *Level_Set_Child(Level_Set *r)
+ Level_Set *Level_Set_Child(Level_Set *r)
 { regtree *p;
   int      x;
 
@@ -178,7 +178,7 @@ inline Level_Set *Level_Set_Child(Level_Set *r)
   return ((Level_Set *) p);
 }
 
-inline Level_Set *Level_Set_Sibling(Level_Set *r)
+ Level_Set *Level_Set_Sibling(Level_Set *r)
 { regtree *p;
   int      x;
 
@@ -199,25 +199,25 @@ inline Level_Set *Level_Set_Sibling(Level_Set *r)
   return ((Level_Set *) p);
 }
 
-inline int Level_Set_Size(Level_Set *r)
+ int Level_Set_Size(Level_Set *r)
 { return (size(((regtree *) r)->right)); }
 
-inline int Level_Set_Level(Level_Set *r)
+ int Level_Set_Level(Level_Set *r)
 { return (level(((regtree *) r)->right)); }
 
-inline int Level_Set_Peak(Level_Set *r)
+ int Level_Set_Peak(Level_Set *r)
 { return (peak(((regtree *) r)->right)); }
 
-msvcextern inline int Level_Set_Leftmost(Level_Set *r)
+msvcextern  int Level_Set_Leftmost(Level_Set *r)
 { return (start(((regtree *) r)->right)); }
 
-inline int Level_Set_Background(Level_Set *r)
+ int Level_Set_Background(Level_Set *r)
 { return (((regtree *) r)->level); }
 
-inline int Level_Set_Id(Level_Set *r)
+ int Level_Set_Id(Level_Set *r)
 { return (((regtree *) r) - regtrees); }
 
-inline Level_Set *Level_Set_Root()
+ Level_Set *Level_Set_Root()
 { return ((Level_Set *) (regtrees + carea)); }
 
   /* List every pixel in the subtree rooted at p */
@@ -280,7 +280,7 @@ static pixel *get_pixels(int area, char *routine)
 
 //  Awk-generated (manager.awk) Component_Tree space management
 
-static inline int comtree_asize(Comtree *tree)
+static  int comtree_asize(Comtree *tree)
 { if (tree->image_ref != NULL)
     return (tree->image_ref->width * tree->image_ref->height * sizeof(regtree));
   else
@@ -298,7 +298,7 @@ typedef struct __Comtree
 static _Comtree *Free_Comtree_List = NULL;
 static int    Comtree_Offset, Comtree_Inuse;
 
-static inline void allocate_comtree_array(Comtree *comtree, int asize, char *routine)
+static  void allocate_comtree_array(Comtree *comtree, int asize, char *routine)
 { _Comtree *object  = (_Comtree *) (((char *) comtree) - Comtree_Offset);
   if (object->asize < asize)
     { object->comtree.array  = Guarded_Realloc(object->comtree.array,asize,routine);
@@ -306,7 +306,7 @@ static inline void allocate_comtree_array(Comtree *comtree, int asize, char *rou
     }
 }
 
-static inline Comtree *new_comtree(int asize, char *routine)
+static  Comtree *new_comtree(int asize, char *routine)
 { _Comtree *object;
 
   if (Free_Comtree_List == NULL)
@@ -324,7 +324,7 @@ static inline Comtree *new_comtree(int asize, char *routine)
   return (&(object->comtree));
 }
 
-static inline Comtree *copy_comtree(Comtree *comtree)
+static  Comtree *copy_comtree(Comtree *comtree)
 { _Comtree *object  = (_Comtree *) (((char *) comtree) - Comtree_Offset);
   Comtree *copy = new_comtree(comtree_asize(comtree),"Copy_Component_Tree");
   Comtree  temp = *copy;
@@ -338,7 +338,7 @@ static inline Comtree *copy_comtree(Comtree *comtree)
 Component_Tree *Copy_Component_Tree(Component_Tree *component_tree)
 { return ((Component_Tree *) copy_comtree((Comtree *) component_tree)); }
 
-static inline void pack_comtree(Comtree *comtree)
+static  void pack_comtree(Comtree *comtree)
 { _Comtree *object  = (_Comtree *) (((char *) comtree) - Comtree_Offset);
   if (object->asize > comtree_asize(comtree))
     { object->asize = comtree_asize(comtree);
@@ -353,7 +353,7 @@ static inline void pack_comtree(Comtree *comtree)
 void Pack_Component_Tree(Component_Tree *component_tree)
 { pack_comtree(((Comtree *) component_tree)); }
 
-static inline void free_comtree(Comtree *comtree)
+static  void free_comtree(Comtree *comtree)
 { _Comtree *object  = (_Comtree *) (((char *) comtree) - Comtree_Offset);
   object->next = Free_Comtree_List;
   Free_Comtree_List = object;
@@ -363,7 +363,7 @@ static inline void free_comtree(Comtree *comtree)
 void Free_Component_Tree(Component_Tree *component_tree)
 { free_comtree(((Comtree *) component_tree)); }
 
-static inline void kill_comtree(Comtree *comtree)
+static  void kill_comtree(Comtree *comtree)
 { _Comtree *object  = (_Comtree *) (((char *) comtree) - Comtree_Offset);
   if (comtree->array != NULL)
     free(comtree->array);
@@ -374,7 +374,7 @@ static inline void kill_comtree(Comtree *comtree)
 void Kill_Component_Tree(Component_Tree *component_tree)
 { kill_comtree(((Comtree *) component_tree)); }
 
-static inline void reset_comtree()
+static  void reset_comtree()
 { _Comtree *object;
   while (Free_Comtree_List != NULL)
     { object = Free_Comtree_List;
@@ -596,7 +596,7 @@ static int chk_height;
 static int chk_depth;
 static int chk_iscon4;
 
-static inline int *boundary_pixels_2d(int p)
+static  int *boundary_pixels_2d(int p)
 { static int bound[8];
   int x, xn, xp;
   int y, yn, yp;
@@ -628,7 +628,7 @@ static inline int *boundary_pixels_2d(int p)
   return (bound);
 }
 
-static inline int *boundary_pixels_3d(int p)
+static  int *boundary_pixels_3d(int p)
 { static int bound[26];
   int x, xn, xp;
   int y, yn, yp;

--- a/src/generated/utilities.c
+++ b/src/generated/utilities.c
@@ -1862,7 +1862,7 @@ static void build_unit_table(Automaton *mach)
 
 // Add a match to the argp'th argument to unit def's list of matches
 
-static inline Candidate *add_match(Unit *def, int argp)
+static  Candidate *add_match(Unit *def, int argp)
 { Candidate *mat = (Candidate  *) Guarded_Malloc(sizeof(Candidate),"Process_Argument");
   mat->next  = def->clist;
   mat->argp  = argp;

--- a/src/generated/water_shed.c
+++ b/src/generated/water_shed.c
@@ -43,7 +43,7 @@ static int *get_chord(int area, char *routine)
   return (Array);
 }
 
-static inline int watershed_2d_ssize(Watershed_2D *part)
+static  int watershed_2d_ssize(Watershed_2D *part)
 { return (sizeof(int)*(part->nbasins+1)); }
 
 
@@ -56,7 +56,7 @@ typedef struct __Watershed_2D
 static _Watershed_2D *Free_Watershed_2D_List = NULL;
 static int    Watershed_2D_Offset, Watershed_2D_Inuse;
 
-static inline void allocate_watershed_2d_seeds(Watershed_2D *watershed_2d, int ssize, char *routine)
+static  void allocate_watershed_2d_seeds(Watershed_2D *watershed_2d, int ssize, char *routine)
 { _Watershed_2D *object  = (_Watershed_2D *) (((char *) watershed_2d) - Watershed_2D_Offset);
   if (object->ssize < ssize)
     { object->watershed_2d.seeds  = Guarded_Realloc(object->watershed_2d.seeds,ssize,routine);
@@ -64,7 +64,7 @@ static inline void allocate_watershed_2d_seeds(Watershed_2D *watershed_2d, int s
     }
 }
 
-static inline Watershed_2D *new_watershed_2d(int ssize, char *routine)
+static  Watershed_2D *new_watershed_2d(int ssize, char *routine)
 { _Watershed_2D *object;
 
   if (Free_Watershed_2D_List == NULL)
@@ -84,7 +84,7 @@ static inline Watershed_2D *new_watershed_2d(int ssize, char *routine)
   return (&(object->watershed_2d));
 }
 
-static inline Watershed_2D *copy_watershed_2d(Watershed_2D *watershed_2d)
+static  Watershed_2D *copy_watershed_2d(Watershed_2D *watershed_2d)
 { _Watershed_2D *object  = (_Watershed_2D *) (((char *) watershed_2d) - Watershed_2D_Offset);
   Watershed_2D *copy = new_watershed_2d(watershed_2d_ssize(watershed_2d),"Copy_Watershed_2D");
   Watershed_2D  temp = *copy;
@@ -100,7 +100,7 @@ static inline Watershed_2D *copy_watershed_2d(Watershed_2D *watershed_2d)
 Watershed_2D *Copy_Watershed_2D(Watershed_2D *watershed_2d)
 { return (copy_watershed_2d(watershed_2d)); }
 
-static inline void pack_watershed_2d(Watershed_2D *watershed_2d)
+static  void pack_watershed_2d(Watershed_2D *watershed_2d)
 { _Watershed_2D *object  = (_Watershed_2D *) (((char *) watershed_2d) - Watershed_2D_Offset);
   if (object->ssize > watershed_2d_ssize(watershed_2d))
     { object->ssize = watershed_2d_ssize(watershed_2d);
@@ -117,7 +117,7 @@ static inline void pack_watershed_2d(Watershed_2D *watershed_2d)
 void Pack_Watershed_2D(Watershed_2D *watershed_2d)
 { pack_watershed_2d(watershed_2d); }
 
-static inline void free_watershed_2d(Watershed_2D *watershed_2d)
+static  void free_watershed_2d(Watershed_2D *watershed_2d)
 { _Watershed_2D *object  = (_Watershed_2D *) (((char *) watershed_2d) - Watershed_2D_Offset);
   object->next = Free_Watershed_2D_List;
   Free_Watershed_2D_List = object;
@@ -129,7 +129,7 @@ static inline void free_watershed_2d(Watershed_2D *watershed_2d)
 void Free_Watershed_2D(Watershed_2D *watershed_2d)
 { free_watershed_2d(watershed_2d); }
 
-static inline void kill_watershed_2d(Watershed_2D *watershed_2d)
+static  void kill_watershed_2d(Watershed_2D *watershed_2d)
 { _Watershed_2D *object  = (_Watershed_2D *) (((char *) watershed_2d) - Watershed_2D_Offset);
   if (watershed_2d->labels != NULL)
     Kill_Image(watershed_2d->labels);
@@ -142,7 +142,7 @@ static inline void kill_watershed_2d(Watershed_2D *watershed_2d)
 void Kill_Watershed_2D(Watershed_2D *watershed_2d)
 { kill_watershed_2d(watershed_2d); }
 
-static inline void reset_watershed_2d()
+static  void reset_watershed_2d()
 { _Watershed_2D *object;
   while (Free_Watershed_2D_List != NULL)
     { object = Free_Watershed_2D_List;
@@ -174,7 +174,7 @@ static int chk_width;
 static int chk_height;
 static int chk_iscon4;
 
-static inline int *boundary_pixels_2d(int p)
+static  int *boundary_pixels_2d(int p)
 { static int bound[8];
   int x, xn, xp;
   int y, yn, yp;
@@ -644,7 +644,7 @@ Watershed_2D *Build_2D_Watershed(Image *frame, int iscon4)
  ****************************************************************************************/
 
 
-static inline int watershed_3d_ssize(Watershed_3D *part)
+static  int watershed_3d_ssize(Watershed_3D *part)
 { return (sizeof(int)*(part->nbasins+1)); }
 
 
@@ -657,7 +657,7 @@ typedef struct __Watershed_3D
 static _Watershed_3D *Free_Watershed_3D_List = NULL;
 static int    Watershed_3D_Offset, Watershed_3D_Inuse;
 
-static inline void allocate_watershed_3d_seeds(Watershed_3D *watershed_3d, int ssize, char *routine)
+static  void allocate_watershed_3d_seeds(Watershed_3D *watershed_3d, int ssize, char *routine)
 { _Watershed_3D *object  = (_Watershed_3D *) (((char *) watershed_3d) - Watershed_3D_Offset);
   if (object->ssize < ssize)
     { object->watershed_3d.seeds  = Guarded_Realloc(object->watershed_3d.seeds,ssize,routine);
@@ -665,7 +665,7 @@ static inline void allocate_watershed_3d_seeds(Watershed_3D *watershed_3d, int s
     }
 }
 
-static inline Watershed_3D *new_watershed_3d(int ssize, char *routine)
+static  Watershed_3D *new_watershed_3d(int ssize, char *routine)
 { _Watershed_3D *object;
 
   if (Free_Watershed_3D_List == NULL)
@@ -685,7 +685,7 @@ static inline Watershed_3D *new_watershed_3d(int ssize, char *routine)
   return (&(object->watershed_3d));
 }
 
-static inline Watershed_3D *copy_watershed_3d(Watershed_3D *watershed_3d)
+static  Watershed_3D *copy_watershed_3d(Watershed_3D *watershed_3d)
 { _Watershed_3D *object  = (_Watershed_3D *) (((char *) watershed_3d) - Watershed_3D_Offset);
   Watershed_3D *copy = new_watershed_3d(watershed_3d_ssize(watershed_3d),"Copy_Watershed_3D");
   Watershed_3D  temp = *copy;
@@ -701,7 +701,7 @@ static inline Watershed_3D *copy_watershed_3d(Watershed_3D *watershed_3d)
 Watershed_3D *Copy_Watershed_3D(Watershed_3D *watershed_3d)
 { return (copy_watershed_3d(watershed_3d)); }
 
-static inline void pack_watershed_3d(Watershed_3D *watershed_3d)
+static  void pack_watershed_3d(Watershed_3D *watershed_3d)
 { _Watershed_3D *object  = (_Watershed_3D *) (((char *) watershed_3d) - Watershed_3D_Offset);
   if (object->ssize > watershed_3d_ssize(watershed_3d))
     { object->ssize = watershed_3d_ssize(watershed_3d);
@@ -718,7 +718,7 @@ static inline void pack_watershed_3d(Watershed_3D *watershed_3d)
 void Pack_Watershed_3D(Watershed_3D *watershed_3d)
 { pack_watershed_3d(watershed_3d); }
 
-static inline void free_watershed_3d(Watershed_3D *watershed_3d)
+static  void free_watershed_3d(Watershed_3D *watershed_3d)
 { _Watershed_3D *object  = (_Watershed_3D *) (((char *) watershed_3d) - Watershed_3D_Offset);
   object->next = Free_Watershed_3D_List;
   Free_Watershed_3D_List = object;
@@ -730,7 +730,7 @@ static inline void free_watershed_3d(Watershed_3D *watershed_3d)
 void Free_Watershed_3D(Watershed_3D *watershed_3d)
 { free_watershed_3d(watershed_3d); }
 
-static inline void kill_watershed_3d(Watershed_3D *watershed_3d)
+static  void kill_watershed_3d(Watershed_3D *watershed_3d)
 { _Watershed_3D *object  = (_Watershed_3D *) (((char *) watershed_3d) - Watershed_3D_Offset);
   if (watershed_3d->labels != NULL)
     Kill_Stack(watershed_3d->labels);
@@ -743,7 +743,7 @@ static inline void kill_watershed_3d(Watershed_3D *watershed_3d)
 void Kill_Watershed_3D(Watershed_3D *watershed_3d)
 { kill_watershed_3d(watershed_3d); }
 
-static inline void reset_watershed_3d()
+static  void reset_watershed_3d()
 { _Watershed_3D *object;
   while (Free_Watershed_3D_List != NULL)
     { object = Free_Watershed_3D_List;
@@ -766,7 +766,7 @@ static int cvolume;
 static int chk_depth;
 static int chk_iscon6;
 
-static inline int *boundary_pixels_3d(int p)
+static  int *boundary_pixels_3d(int p)
 { static int bound[26];
   int x, xn, xp;
   int y, yn, yp;

--- a/src/hmm-reclassify.c
+++ b/src/hmm-reclassify.c
@@ -197,7 +197,7 @@ void Measurements_Reference_Free( Measurements_Reference* this )
   }
 }
 
-inline void Measurements_Reference_Reset( Measurements_Reference *this)
+ void Measurements_Reference_Reset( Measurements_Reference *this)
 { Measurements **w = this->whiskers;
   memset( w, 0, this->nwhiskers * sizeof(Measurements*) );
 }
@@ -211,7 +211,7 @@ void Measurements_Reference_Build( Measurements_Reference *this, Measurements *r
       w[row[nseg].state] = row + nseg;
 }
 
-inline int Measurements_Reference_Has_Full_Count( Measurements_Reference *this )
+ int Measurements_Reference_Has_Full_Count( Measurements_Reference *this )
 { int n = this->nwhiskers;
   Measurements **w = this->whiskers;
   while(n--)
@@ -727,7 +727,7 @@ void heap_free( heap *h )
   }
 }
 
-inline void heapify( heap* h, int i )
+ void heapify( heap* h, int i )
 { int left  = heap_left(i),
       right = heap_right(i),
       argmax = i;
@@ -752,13 +752,13 @@ inline void heapify( heap* h, int i )
 }
 
 // Organizes an unorganized heap in O(h->size)
-inline void heap_build( heap *h )
+ void heap_build( heap *h )
 { int i = h->size/2;
   while(i-- > 1)
     heapify(h,i);
 }
 
-inline real *heap_pop_head( heap *h )
+ real *heap_pop_head( heap *h )
 { real *max,
       **data = h->data - 1;
   if( h->size < 1 )
@@ -769,7 +769,7 @@ inline real *heap_pop_head( heap *h )
   return max;
 }
 
-inline real *heap_pop_and_insert( heap *h, real *v )
+ real *heap_pop_and_insert( heap *h, real *v )
 { real *max,
       **data = h->data - 1;
   if( h->size < 1 )
@@ -780,7 +780,7 @@ inline real *heap_pop_and_insert( heap *h, real *v )
   return max;
 }
 
-inline void heap_insert( heap *h, real *v )
+ void heap_insert( heap *h, real *v )
 { real **data = h->data - 1;
   size_t i,parent;
   if( h->size+1 > h->maxsize )

--- a/src/image_lib.p
+++ b/src/image_lib.p
@@ -76,10 +76,10 @@ static uint32 *get_raster(int npixels, char *routine)
 
 // Awk-generated (manager.awk) Image memory management
 
-static inline int image_asize(Image *image)
+static  int image_asize(Image *image)
 { return (image->height*image->width*image->kind); }
 
-static inline int image_tsize(Image *image)
+static  int image_tsize(Image *image)
 { return (strlen(image->text)+1); }
 
 MANAGER -r Image array:asize text:tsize
@@ -91,10 +91,10 @@ void Reset_Image()
 
 // Awk-generated (manager.awk) Stack memory management
 
-static inline int stack_vsize(Stack *stack)
+static  int stack_vsize(Stack *stack)
 { return (stack->depth*stack->height*stack->width*stack->kind); }
 
-static inline int stack_tsize(Stack *stack)
+static  int stack_tsize(Stack *stack)
 { return (strlen(stack->text)+1); }
 
 MANAGER -r Stack array:vsize text:tsize

--- a/src/level_set.p
+++ b/src/level_set.p
@@ -125,14 +125,14 @@ int Get_Component_Tree_Connectivity(Component_Tree *atree)
  *                                                                                      *
  ****************************************************************************************/
 
-static inline int size(int cont)
+static  int size(int cont)
 { if (cont > 0)
     return (regtrees[cont].size);
   else
     return (1);
 }
 
-static inline int level(int cont)
+static  int level(int cont)
 { if (cont > 0)
     return (regtrees[cont].level);
   else if (value8 != NULL)
@@ -141,7 +141,7 @@ static inline int level(int cont)
     return (value16[-cont]);
 }
 
-static inline int peak(int cont)
+static  int peak(int cont)
 { if (cont > 0)
     return (regtrees[cont].peak);
   else if (value8 != NULL)
@@ -150,14 +150,14 @@ static inline int peak(int cont)
     return (value16[-cont]);
 }
 
-static inline int start(int cont)
+static  int start(int cont)
 { if (cont > 0)
     return (regtrees[cont].start);
   else
     return (-cont);
 }
 
-inline Level_Set *Level_Set_Child(Level_Set *r)
+ Level_Set *Level_Set_Child(Level_Set *r)
 { regtree *p;
   int      x;
 
@@ -178,7 +178,7 @@ inline Level_Set *Level_Set_Child(Level_Set *r)
   return ((Level_Set *) p);
 }
 
-inline Level_Set *Level_Set_Sibling(Level_Set *r)
+ Level_Set *Level_Set_Sibling(Level_Set *r)
 { regtree *p;
   int      x;
 
@@ -199,25 +199,25 @@ inline Level_Set *Level_Set_Sibling(Level_Set *r)
   return ((Level_Set *) p);
 }
 
-inline int Level_Set_Size(Level_Set *r)
+ int Level_Set_Size(Level_Set *r)
 { return (size(((regtree *) r)->right)); }
 
-inline int Level_Set_Level(Level_Set *r)
+ int Level_Set_Level(Level_Set *r)
 { return (level(((regtree *) r)->right)); }
 
-inline int Level_Set_Peak(Level_Set *r)
+ int Level_Set_Peak(Level_Set *r)
 { return (peak(((regtree *) r)->right)); }
 
-msvcextern inline int Level_Set_Leftmost(Level_Set *r)
+msvcextern  int Level_Set_Leftmost(Level_Set *r)
 { return (start(((regtree *) r)->right)); }
 
-inline int Level_Set_Background(Level_Set *r)
+ int Level_Set_Background(Level_Set *r)
 { return (((regtree *) r)->level); }
 
-inline int Level_Set_Id(Level_Set *r)
+ int Level_Set_Id(Level_Set *r)
 { return (((regtree *) r) - regtrees); }
 
-inline Level_Set *Level_Set_Root()
+ Level_Set *Level_Set_Root()
 { return ((Level_Set *) (regtrees + carea)); }
 
   /* List every pixel in the subtree rooted at p */
@@ -280,7 +280,7 @@ static pixel *get_pixels(int area, char *routine)
 
 //  Awk-generated (manager.awk) Component_Tree space management
 
-static inline int comtree_asize(Comtree *tree)
+static  int comtree_asize(Comtree *tree)
 { if (tree->image_ref != NULL)
     return (tree->image_ref->width * tree->image_ref->height * sizeof(regtree));
   else
@@ -499,7 +499,7 @@ static int chk_height;
 static int chk_depth;
 static int chk_iscon4;
 
-static inline int *boundary_pixels_2d(int p)
+static  int *boundary_pixels_2d(int p)
 { static int bound[8];
   int x, xn, xp;
   int y, yn, yp;
@@ -531,7 +531,7 @@ static inline int *boundary_pixels_2d(int p)
   return (bound);
 }
 
-static inline int *boundary_pixels_3d(int p)
+static  int *boundary_pixels_3d(int p)
 { static int bound[26];
   int x, xn, xp;
   int y, yn, yp;

--- a/src/measure.c
+++ b/src/measure.c
@@ -59,7 +59,7 @@ static int _score_cmp( const void *a, const void *b )
 // corresponding to the follicle and return dI/di
 // (I is the index as it proceeds outward from the
 // follicle; dI/di is either 1 or -1).
-static inline float _side_dist_to_face( Whisker_Seg* w, int cx, int cy, int idx )
+static  float _side_dist_to_face( Whisker_Seg* w, int cx, int cy, int idx )
 { float dx = w->x[idx] - cx,
         dy = w->y[idx] - cy;
   return dx*dx + dy*dy;

--- a/src/merge.c
+++ b/src/merge.c
@@ -282,13 +282,13 @@ int CollisionTable_Next( CollisionTable *this, CollisionTableCursor *cursor )
  * The returned array is a static result so it's only valid for one call.
  */
 
-inline float _trace_overlap_dist( Whisker_Seg *wa, Whisker_Seg *wb, int ia, int ib )
+ float _trace_overlap_dist( Whisker_Seg *wa, Whisker_Seg *wb, int ia, int ib )
 { float dx = wa->x[ia] - wb->x[ib],
         dy = wa->y[ia] - wb->y[ib];
   return dx*dx + dy*dy;
 }
 
-inline int _trace_overlap_bounds_check( Whisker_Seg *w, int i )
+ int _trace_overlap_bounds_check( Whisker_Seg *w, int i )
 { return i>=0 && i<w->len;
 }
 
@@ -419,11 +419,11 @@ int _cmp_whisker_seg_frame( const void *a, const void *b )
 { return ((Whisker_Seg*)a)->time - ((Whisker_Seg*)b)->time;
 }
 
-inline int _is_whisker_interval_significant( Whisker_Seg *w, int a, int b, float thresh )
+ int _is_whisker_interval_significant( Whisker_Seg *w, int a, int b, float thresh )
 { return (b-a) >= (thresh * w->len);
 }
 
-inline float _whisker_seg_score_sum( Whisker_Seg *w )
+ float _whisker_seg_score_sum( Whisker_Seg *w )
 { float s  = 0,
        *sc = w->scores;
   int n = w->len;

--- a/src/poly.c
+++ b/src/poly.c
@@ -24,7 +24,7 @@
 #define DEBUG_POLYFIT_REUSE
 #endif
 
-inline double polyval(double *p, int degree, double x)
+ double polyval(double *p, int degree, double x)
 { double acc  = 0.0,
          xton = 1.0,
          *end = p + degree + 1; // #coeffs = degree + 1
@@ -36,7 +36,7 @@ inline double polyval(double *p, int degree, double x)
   return acc;
 }
 
-inline int polymul_nelem_dest(int na, int nb)
+ int polymul_nelem_dest(int na, int nb)
 { return na + nb - 1;
 }
 
@@ -44,7 +44,7 @@ inline int polymul_nelem_dest(int na, int nb)
 // Multiplies polynomials by convolution.  Expects destination to be
 // pre-allocated with na+nb+1 # of elements (see: polymul_nelem_dest).
 //
-inline void polymul(double *a, int na, double *b, int nb, double* dest )
+ void polymul(double *a, int na, double *b, int nb, double* dest )
 { int j,k;
   double *aend = a + na;
   nb -= 1; // shift this to index of last element for convenience
@@ -65,7 +65,7 @@ inline void polymul(double *a, int na, double *b, int nb, double* dest )
 // In place addition of two polynomials.
 // Requires na > nb.
 //
-inline void polyadd_ip_left(double *a, int na, double *b, int nb )
+ void polyadd_ip_left(double *a, int na, double *b, int nb )
 { 
 #ifdef DEBUG_POLYADD_IP
   assert(na>nb);
@@ -74,7 +74,7 @@ inline void polyadd_ip_left(double *a, int na, double *b, int nb )
     a[nb] += b[nb];
 }
 
-inline void polysub_ip_left(double *a, int na, double *b, int nb )
+ void polysub_ip_left(double *a, int na, double *b, int nb )
 { 
 #ifdef DEBUG_POLYADD_IP
   assert(na>nb);
@@ -83,7 +83,7 @@ inline void polysub_ip_left(double *a, int na, double *b, int nb )
     a[nb] -= b[nb];
 }
 
-inline void polyadd ( double *a, int na, double *b, int nb, double *dest )
+ void polyadd ( double *a, int na, double *b, int nb, double *dest )
 { 
   while( na > nb )
     dest[--na] = a[na];
@@ -94,7 +94,7 @@ inline void polyadd ( double *a, int na, double *b, int nb, double *dest )
     dest[na] = a[na] + b[na];
 }
 
-inline void polysub ( double *a, int na, double *b, int nb, double *dest )
+ void polysub ( double *a, int na, double *b, int nb, double *dest )
 { 
   while( na > nb )
     dest[--na] = a[na];
@@ -107,7 +107,7 @@ inline void polysub ( double *a, int na, double *b, int nb, double *dest )
 //
 // Derivative of polynomial
 //
-inline void polyder_ip( double *a, int na, int times )
+ void polyder_ip( double *a, int na, int times )
 { int i;
   if(times>0)
   { for(i=1;i<na;i++)
@@ -270,7 +270,7 @@ double Vandermonde_Determinant_Log2( double *x, int n )
 // POLYFIT
 //
 
-inline int polyfit_size_workspace(int n, int degree )
+ int polyfit_size_workspace(int n, int degree )
 { int ncoeffs = degree+1;
   return (n + 1 + ncoeffs)*ncoeffs;
 }

--- a/src/seed.c
+++ b/src/seed.c
@@ -352,7 +352,7 @@ Seed_Vector *find_seeds(Contour *trace, Image *image)
 
 // Warning: no bounds checking
 #if 0
-inline void _compute_seed_from_point_helper(
+ void _compute_seed_from_point_helper(
               Image* image, int x, int y, int cx, int cy,
               uint8 *best, int *bp )
 { int tp = x+cx + image->width * (y+cy);
@@ -374,7 +374,7 @@ inline void _compute_seed_from_point_helper(
   }                                                                 \
 }
 
-inline float _compute_seed_from_point_eigennorm( float th )
+ float _compute_seed_from_point_eigennorm( float th )
 { //float th = atanf( slope );
   float cs = fabsf(cos(th)),
         ss = fabsf(sin(th));

--- a/src/svd.c
+++ b/src/svd.c
@@ -33,7 +33,7 @@
 
 #define SIGN(a,b) ((b) >= 0.0 ? fabs(a) : -fabs(a))
 
-inline void svd_threshold( double thresh, double *w, int n )
+ void svd_threshold( double thresh, double *w, int n )
 { double *e = w+n;
   while(e-- > w)
     if(fabs(*e) < thresh)
@@ -44,7 +44,7 @@ inline void svd_threshold( double thresh, double *w, int n )
 // Solves A x = b using SVD of A ( U W V' = A, W = diag(w) )
 //     That is: x = V U' b / W
 //
-inline void svd_backsub( double *u, double *w, double *v, int nrows, int ncols, double *b, double *x )
+ void svd_backsub( double *u, double *w, double *v, int nrows, int ncols, double *b, double *x )
 { double *utb;
   // U'b
   utb = matmul_left_transpose_static( u, nrows, ncols,

--- a/src/tiff_image.c
+++ b/src/tiff_image.c
@@ -70,7 +70,7 @@ typedef struct __Tiff_Histogram
 static _Tiff_Histogram *Free_Tiff_Histogram_List = NULL;
 static int    Tiff_Histogram_Offset, Tiff_Histogram_Inuse;
 
-static inline Tiff_Histogram *new_tiff_histogram(char *routine)
+static  Tiff_Histogram *new_tiff_histogram(char *routine)
 { _Tiff_Histogram *object;
 
   if (Free_Tiff_Histogram_List == NULL)
@@ -85,7 +85,7 @@ static inline Tiff_Histogram *new_tiff_histogram(char *routine)
   return (&(object->tiff_histogram));
 }
 
-static inline Tiff_Histogram *copy_tiff_histogram(Tiff_Histogram *tiff_histogram)
+static  Tiff_Histogram *copy_tiff_histogram(Tiff_Histogram *tiff_histogram)
 { Tiff_Histogram *copy = new_tiff_histogram("Copy_Tiff_Histogram");
   *copy = *tiff_histogram;
   return (copy);
@@ -94,7 +94,7 @@ static inline Tiff_Histogram *copy_tiff_histogram(Tiff_Histogram *tiff_histogram
 Tiff_Histogram *Copy_Tiff_Histogram(Tiff_Histogram *tiff_histogram)
 { return (copy_tiff_histogram(tiff_histogram)); }
 
-static inline void free_tiff_histogram(Tiff_Histogram *tiff_histogram)
+static  void free_tiff_histogram(Tiff_Histogram *tiff_histogram)
 { _Tiff_Histogram *object  = (_Tiff_Histogram *) (((char *) tiff_histogram) - Tiff_Histogram_Offset);
   object->next = Free_Tiff_Histogram_List;
   Free_Tiff_Histogram_List = object;
@@ -104,7 +104,7 @@ static inline void free_tiff_histogram(Tiff_Histogram *tiff_histogram)
 void Free_Tiff_Histogram(Tiff_Histogram *tiff_histogram)
 { free_tiff_histogram(tiff_histogram); }
 
-static inline void kill_tiff_histogram(Tiff_Histogram *tiff_histogram)
+static  void kill_tiff_histogram(Tiff_Histogram *tiff_histogram)
 {
   free(((char *) tiff_histogram) - Tiff_Histogram_Offset);
   Tiff_Histogram_Inuse -= 1;
@@ -113,7 +113,7 @@ static inline void kill_tiff_histogram(Tiff_Histogram *tiff_histogram)
 void Kill_Tiff_Histogram(Tiff_Histogram *tiff_histogram)
 { kill_tiff_histogram(tiff_histogram); }
 
-static inline void reset_tiff_histogram()
+static  void reset_tiff_histogram()
 { _Tiff_Histogram *object;
   while (Free_Tiff_Histogram_List != NULL)
     { object = Free_Tiff_Histogram_List;
@@ -129,7 +129,7 @@ void Reset_Tiff_Histogram()
 int Tiff_Histogram_Usage()
 { return (Tiff_Histogram_Inuse); }
 
-static inline int tiff_channel_psize(Tiff_Channel *channel)
+static  int tiff_channel_psize(Tiff_Channel *channel)
 { return (channel->bytes_per_pixel*channel->width*channel->height); }
 
 
@@ -142,7 +142,7 @@ typedef struct __Tiff_Channel
 static _Tiff_Channel *Free_Tiff_Channel_List = NULL;
 static int    Tiff_Channel_Offset, Tiff_Channel_Inuse;
 
-static inline void allocate_tiff_channel_plane(Tiff_Channel *tiff_channel, int psize, char *routine)
+static  void allocate_tiff_channel_plane(Tiff_Channel *tiff_channel, int psize, char *routine)
 { _Tiff_Channel *object  = (_Tiff_Channel *) (((char *) tiff_channel) - Tiff_Channel_Offset);
   if (object->psize < psize)
     { if (object->psize == 0)
@@ -152,7 +152,7 @@ static inline void allocate_tiff_channel_plane(Tiff_Channel *tiff_channel, int p
     }
 }
 
-static inline Tiff_Channel *new_tiff_channel(int psize, char *routine)
+static  Tiff_Channel *new_tiff_channel(int psize, char *routine)
 { _Tiff_Channel *object;
 
   if (Free_Tiff_Channel_List == NULL)
@@ -170,7 +170,7 @@ static inline Tiff_Channel *new_tiff_channel(int psize, char *routine)
   return (&(object->tiff_channel));
 }
 
-static inline Tiff_Channel *copy_tiff_channel(Tiff_Channel *tiff_channel)
+static  Tiff_Channel *copy_tiff_channel(Tiff_Channel *tiff_channel)
 { Tiff_Channel *copy = new_tiff_channel(tiff_channel_psize(tiff_channel),"Copy_Tiff_Channel");
   Tiff_Channel  temp = *copy;
   *copy = *tiff_channel;
@@ -185,7 +185,7 @@ static inline Tiff_Channel *copy_tiff_channel(Tiff_Channel *tiff_channel)
 Tiff_Channel *Copy_Tiff_Channel(Tiff_Channel *tiff_channel)
 { return (copy_tiff_channel(tiff_channel)); }
 
-static inline void pack_tiff_channel(Tiff_Channel *tiff_channel)
+static  void pack_tiff_channel(Tiff_Channel *tiff_channel)
 { _Tiff_Channel *object  = (_Tiff_Channel *) (((char *) tiff_channel) - Tiff_Channel_Offset);
   if (object->psize > tiff_channel_psize(tiff_channel))
     { object->psize = tiff_channel_psize(tiff_channel);
@@ -202,7 +202,7 @@ static inline void pack_tiff_channel(Tiff_Channel *tiff_channel)
 void Pack_Tiff_Channel(Tiff_Channel *tiff_channel)
 { pack_tiff_channel(tiff_channel); }
 
-static inline void free_tiff_channel(Tiff_Channel *tiff_channel)
+static  void free_tiff_channel(Tiff_Channel *tiff_channel)
 { _Tiff_Channel *object  = (_Tiff_Channel *) (((char *) tiff_channel) - Tiff_Channel_Offset);
   object->next = Free_Tiff_Channel_List;
   Free_Tiff_Channel_List = object;
@@ -214,7 +214,7 @@ static inline void free_tiff_channel(Tiff_Channel *tiff_channel)
 void Free_Tiff_Channel(Tiff_Channel *tiff_channel)
 { free_tiff_channel(tiff_channel); }
 
-static inline void kill_tiff_channel(Tiff_Channel *tiff_channel)
+static  void kill_tiff_channel(Tiff_Channel *tiff_channel)
 { _Tiff_Channel *object  = (_Tiff_Channel *) (((char *) tiff_channel) - Tiff_Channel_Offset);
   if (tiff_channel->histogram != NULL)
     Kill_Tiff_Histogram(tiff_channel->histogram);
@@ -227,7 +227,7 @@ static inline void kill_tiff_channel(Tiff_Channel *tiff_channel)
 void Kill_Tiff_Channel(Tiff_Channel *tiff_channel)
 { kill_tiff_channel(tiff_channel); }
 
-static inline void reset_tiff_channel()
+static  void reset_tiff_channel()
 { _Tiff_Channel *object;
   while (Free_Tiff_Channel_List != NULL)
     { object = Free_Tiff_Channel_List;
@@ -259,10 +259,10 @@ static unsigned char *get_code_vector(int size, char *routine)
   return (Code_Vector);
 }
 
-static inline int tiff_image_csize(Tiff_Image *image)
+static  int tiff_image_csize(Tiff_Image *image)
 { return (sizeof(Tiff_Channel *)*image->number_channels); }
 
-static inline int tiff_image_msize(Tiff_Image *image)
+static  int tiff_image_msize(Tiff_Image *image)
 { if (image->channels[0]->interpretation == CHAN_MAPPED)
     return (3*sizeof(unsigned short)*(1 << image->channels[0]->scale));
   else
@@ -280,7 +280,7 @@ typedef struct __Tiff_Image
 static _Tiff_Image *Free_Tiff_Image_List = NULL;
 static int    Tiff_Image_Offset, Tiff_Image_Inuse;
 
-static inline void allocate_tiff_image_channels(Tiff_Image *tiff_image, int csize, char *routine)
+static  void allocate_tiff_image_channels(Tiff_Image *tiff_image, int csize, char *routine)
 { _Tiff_Image *object  = (_Tiff_Image *) (((char *) tiff_image) - Tiff_Image_Offset);
   if (object->csize < csize)
     { if (object->csize == 0)
@@ -290,7 +290,7 @@ static inline void allocate_tiff_image_channels(Tiff_Image *tiff_image, int csiz
     }
 }
 
-static inline void allocate_tiff_image_map(Tiff_Image *tiff_image, int msize, char *routine)
+static  void allocate_tiff_image_map(Tiff_Image *tiff_image, int msize, char *routine)
 { _Tiff_Image *object  = (_Tiff_Image *) (((char *) tiff_image) - Tiff_Image_Offset);
   if (object->msize < msize)
     { if (object->msize == 0)
@@ -300,7 +300,7 @@ static inline void allocate_tiff_image_map(Tiff_Image *tiff_image, int msize, ch
     }
 }
 
-static inline Tiff_Image *new_tiff_image(int csize, int msize, char *routine)
+static  Tiff_Image *new_tiff_image(int csize, int msize, char *routine)
 { _Tiff_Image *object;
 
   if (Free_Tiff_Image_List == NULL)
@@ -319,7 +319,7 @@ static inline Tiff_Image *new_tiff_image(int csize, int msize, char *routine)
   return (&(object->tiff_image));
 }
 
-static inline Tiff_Image *copy_tiff_image(Tiff_Image *tiff_image)
+static  Tiff_Image *copy_tiff_image(Tiff_Image *tiff_image)
 { Tiff_Image *copy = new_tiff_image(tiff_image_csize(tiff_image),tiff_image_msize(tiff_image),"Copy_Tiff_Image");
   Tiff_Image  temp = *copy;
   *copy = *tiff_image;
@@ -332,7 +332,7 @@ static inline Tiff_Image *copy_tiff_image(Tiff_Image *tiff_image)
   return (copy);
 }
 
-static inline void pack_tiff_image(Tiff_Image *tiff_image)
+static  void pack_tiff_image(Tiff_Image *tiff_image)
 { _Tiff_Image *object  = (_Tiff_Image *) (((char *) tiff_image) - Tiff_Image_Offset);
   if (object->csize > tiff_image_csize(tiff_image))
     { object->csize = tiff_image_csize(tiff_image);
@@ -356,14 +356,14 @@ static inline void pack_tiff_image(Tiff_Image *tiff_image)
     }
 }
 
-static inline void free_tiff_image(Tiff_Image *tiff_image)
+static  void free_tiff_image(Tiff_Image *tiff_image)
 { _Tiff_Image *object  = (_Tiff_Image *) (((char *) tiff_image) - Tiff_Image_Offset);
   object->next = Free_Tiff_Image_List;
   Free_Tiff_Image_List = object;
   Tiff_Image_Inuse -= 1;
 }
 
-static inline void kill_tiff_image(Tiff_Image *tiff_image)
+static  void kill_tiff_image(Tiff_Image *tiff_image)
 { _Tiff_Image *object  = (_Tiff_Image *) (((char *) tiff_image) - Tiff_Image_Offset);
   if (object->msize != 0)
     free(tiff_image->map);
@@ -373,7 +373,7 @@ static inline void kill_tiff_image(Tiff_Image *tiff_image)
   Tiff_Image_Inuse -= 1;
 }
 
-static inline void reset_tiff_image()
+static  void reset_tiff_image()
 { _Tiff_Image *object;
   while (Free_Tiff_Image_List != NULL)
     { object = Free_Tiff_Image_List;
@@ -804,7 +804,7 @@ static void flip_columns(Tiff_Channel *channel, int width, int height)
     }
 }
 
-static inline unsigned int get_integer_tag(Tiff_IFD *ifd, int label, int *error)
+static  unsigned int get_integer_tag(Tiff_IFD *ifd, int label, int *error)
 { void     *p;
   int       count;
   Tiff_Type type;
@@ -836,7 +836,7 @@ static inline unsigned int get_integer_tag(Tiff_IFD *ifd, int label, int *error)
 
 static char Error_String[1000];
 
-static inline void *error(char *text)
+static  void *error(char *text)
 { strcpy(Error_String,text);
   return (NULL);
 }

--- a/src/tiff_io.c
+++ b/src/tiff_io.c
@@ -191,7 +191,7 @@ typedef struct __Treader
 static _Treader *Free_Treader_List = NULL;
 static int    Treader_Offset, Treader_Inuse;
 
-static inline Treader *new_treader(char *routine)
+static  Treader *new_treader(char *routine)
 { _Treader *object;
 
   if (Free_Treader_List == NULL)
@@ -206,7 +206,7 @@ static inline Treader *new_treader(char *routine)
   return (&(object->treader));
 }
 
-static inline Treader *copy_treader(Treader *treader)
+static  Treader *copy_treader(Treader *treader)
 { Treader *copy = new_treader("Copy_Tiff_Reader");
   *copy = *treader;
   return (copy);
@@ -215,20 +215,20 @@ static inline Treader *copy_treader(Treader *treader)
 Tiff_Reader *Copy_Tiff_Reader(Tiff_Reader *tiff_reader)
 { return ((Tiff_Reader *) copy_treader((Treader *) tiff_reader)); }
 
-static inline void free_treader(Treader *treader)
+static  void free_treader(Treader *treader)
 { _Treader *object  = (_Treader *) (((char *) treader) - Treader_Offset);
   object->next = Free_Treader_List;
   Free_Treader_List = object;
   Treader_Inuse -= 1;
 }
 
-static inline void kill_treader(Treader *treader)
+static  void kill_treader(Treader *treader)
 {
   free(((char *) treader) - Treader_Offset);
   Treader_Inuse -= 1;
 }
 
-static inline void reset_treader()
+static  void reset_treader()
 { _Treader *object;
   while (Free_Treader_List != NULL)
     { object = Free_Treader_List;
@@ -256,7 +256,7 @@ void Kill_Tiff_Reader(Tiff_Reader *tif)
   kill_treader(rtif);
 }
 
-static inline int twriter_asize(Twriter *tif)
+static  int twriter_asize(Twriter *tif)
 { return (tif->ano_count); }
 
 
@@ -269,7 +269,7 @@ typedef struct __Twriter
 static _Twriter *Free_Twriter_List = NULL;
 static int    Twriter_Offset, Twriter_Inuse;
 
-static inline void allocate_twriter_annotation(Twriter *twriter, int asize, char *routine)
+static  void allocate_twriter_annotation(Twriter *twriter, int asize, char *routine)
 { _Twriter *object  = (_Twriter *) (((char *) twriter) - Twriter_Offset);
   if (object->asize < asize)
     { if (object->asize == 0)
@@ -279,7 +279,7 @@ static inline void allocate_twriter_annotation(Twriter *twriter, int asize, char
     }
 }
 
-static inline Twriter *new_twriter(int asize, char *routine)
+static  Twriter *new_twriter(int asize, char *routine)
 { _Twriter *object;
 
   if (Free_Twriter_List == NULL)
@@ -296,7 +296,7 @@ static inline Twriter *new_twriter(int asize, char *routine)
   return (&(object->twriter));
 }
 
-static inline Twriter *copy_twriter(Twriter *twriter)
+static  Twriter *copy_twriter(Twriter *twriter)
 { Twriter *copy = new_twriter(twriter_asize(twriter),"Copy_Tiff_Writer");
   Twriter  temp = *copy;
   *copy = *twriter;
@@ -309,7 +309,7 @@ static inline Twriter *copy_twriter(Twriter *twriter)
 Tiff_Writer *Copy_Tiff_Writer(Tiff_Writer *tiff_writer)
 { return ((Tiff_Writer *) copy_twriter((Twriter *) tiff_writer)); }
 
-static inline void pack_twriter(Twriter *twriter)
+static  void pack_twriter(Twriter *twriter)
 { _Twriter *object  = (_Twriter *) (((char *) twriter) - Twriter_Offset);
   if (object->asize > twriter_asize(twriter))
     { object->asize = twriter_asize(twriter);
@@ -326,7 +326,7 @@ static inline void pack_twriter(Twriter *twriter)
 void Pack_Tiff_Writer(Tiff_Writer *tiff_writer)
 { pack_twriter(((Twriter *) tiff_writer)); }
 
-static inline void free_twriter(Twriter *twriter)
+static  void free_twriter(Twriter *twriter)
 { _Twriter *object  = (_Twriter *) (((char *) twriter) - Twriter_Offset);
   object->next = Free_Twriter_List;
   Free_Twriter_List = object;
@@ -336,7 +336,7 @@ static inline void free_twriter(Twriter *twriter)
 void Free_Tiff_Writer(Tiff_Writer *tiff_writer)
 { free_twriter(((Twriter *) tiff_writer)); }
 
-static inline void kill_twriter(Twriter *twriter)
+static  void kill_twriter(Twriter *twriter)
 { _Twriter *object  = (_Twriter *) (((char *) twriter) - Twriter_Offset);
   if (object->asize != 0)
     free(twriter->annotation);
@@ -347,7 +347,7 @@ static inline void kill_twriter(Twriter *twriter)
 void Kill_Tiff_Writer(Tiff_Writer *tiff_writer)
 { kill_twriter(((Twriter *) tiff_writer)); }
 
-static inline void reset_twriter()
+static  void reset_twriter()
 { _Twriter *object;
   while (Free_Twriter_List != NULL)
     { object = Free_Twriter_List;
@@ -366,7 +366,7 @@ int Tiff_Writer_Usage()
 
 #ifndef _MSC_VER // annotator not windows compatible due to unistd.h dependency
 
-static inline int tannotator_asize(Tannotator *tif)
+static  int tannotator_asize(Tannotator *tif)
 { return (tif->ano_count); }
 
 
@@ -379,7 +379,7 @@ typedef struct __Tannotator
 static _Tannotator *Free_Tannotator_List = NULL;
 static int    Tannotator_Offset, Tannotator_Inuse;
 
-static inline void allocate_tannotator_annotation(Tannotator *tannotator, int asize, char *routine)
+static  void allocate_tannotator_annotation(Tannotator *tannotator, int asize, char *routine)
 { _Tannotator *object  = (_Tannotator *) (((char *) tannotator) - Tannotator_Offset);
   if (object->asize < asize)
     { if (object->asize == 0)
@@ -389,7 +389,7 @@ static inline void allocate_tannotator_annotation(Tannotator *tannotator, int as
     }
 }
 
-static inline Tannotator *new_tannotator(int asize, char *routine)
+static  Tannotator *new_tannotator(int asize, char *routine)
 { _Tannotator *object;
 
   if (Free_Tannotator_List == NULL)
@@ -406,7 +406,7 @@ static inline Tannotator *new_tannotator(int asize, char *routine)
   return (&(object->tannotator));
 }
 
-static inline Tannotator *copy_tannotator(Tannotator *tannotator)
+static  Tannotator *copy_tannotator(Tannotator *tannotator)
 { Tannotator *copy = new_tannotator(tannotator_asize(tannotator),"Copy_Tiff_Annotator");
   Tannotator  temp = *copy;
   *copy = *tannotator;
@@ -419,7 +419,7 @@ static inline Tannotator *copy_tannotator(Tannotator *tannotator)
 Tiff_Annotator *Copy_Tiff_Annotator(Tiff_Annotator *tiff_annotator)
 { return ((Tiff_Annotator *) copy_tannotator((Tannotator *) tiff_annotator)); }
 
-static inline void pack_tannotator(Tannotator *tannotator)
+static  void pack_tannotator(Tannotator *tannotator)
 { _Tannotator *object  = (_Tannotator *) (((char *) tannotator) - Tannotator_Offset);
   if (object->asize > tannotator_asize(tannotator))
     { object->asize = tannotator_asize(tannotator);
@@ -436,14 +436,14 @@ static inline void pack_tannotator(Tannotator *tannotator)
 void Pack_Tiff_Annotator(Tiff_Annotator *tiff_annotator)
 { pack_tannotator(((Tannotator *) tiff_annotator)); }
 
-static inline void free_tannotator(Tannotator *tannotator)
+static  void free_tannotator(Tannotator *tannotator)
 { _Tannotator *object  = (_Tannotator *) (((char *) tannotator) - Tannotator_Offset);
   object->next = Free_Tannotator_List;
   Free_Tannotator_List = object;
   Tannotator_Inuse -= 1;
 }
 
-static inline void kill_tannotator(Tannotator *tannotator)
+static  void kill_tannotator(Tannotator *tannotator)
 { _Tannotator *object  = (_Tannotator *) (((char *) tannotator) - Tannotator_Offset);
   if (object->asize != 0)
     free(tannotator->annotation);
@@ -451,7 +451,7 @@ static inline void kill_tannotator(Tannotator *tannotator)
   Tannotator_Inuse -= 1;
 }
 
-static inline void reset_tannotator()
+static  void reset_tannotator()
 { _Tannotator *object;
   while (Free_Tannotator_List != NULL)
     { object = Free_Tannotator_List;
@@ -513,13 +513,13 @@ static uint8 *get_lsm_decode(int size, char *routine)
   return (LSM_Decode_Block);
 }
 
-static inline int tifd_tsize(TIFD *tifd)
+static  int tifd_tsize(TIFD *tifd)
 { return (sizeof(Tif_Tag)*tifd->maxtags); }
 
-static inline int tifd_dsize(TIFD *tifd)
+static  int tifd_dsize(TIFD *tifd)
 { return (tifd->dsize); }
 
-static inline int tifd_vsize(TIFD *tifd)
+static  int tifd_vsize(TIFD *tifd)
 { return (tifd->vmax); }
 
 
@@ -534,7 +534,7 @@ typedef struct __TIFD
 static _TIFD *Free_TIFD_List = NULL;
 static int    TIFD_Offset, TIFD_Inuse;
 
-static inline void allocate_tifd_tags(TIFD *tifd, int tsize, char *routine)
+static  void allocate_tifd_tags(TIFD *tifd, int tsize, char *routine)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   if (object->tsize < tsize)
     { if (object->tsize == 0)
@@ -544,7 +544,7 @@ static inline void allocate_tifd_tags(TIFD *tifd, int tsize, char *routine)
     }
 }
 
-static inline void allocate_tifd_values(TIFD *tifd, int vsize, char *routine)
+static  void allocate_tifd_values(TIFD *tifd, int vsize, char *routine)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   if (object->vsize < vsize)
     { if (object->vsize == 0)
@@ -554,7 +554,7 @@ static inline void allocate_tifd_values(TIFD *tifd, int vsize, char *routine)
     }
 }
 
-static inline void allocate_tifd_data(TIFD *tifd, int dsize, char *routine)
+static  void allocate_tifd_data(TIFD *tifd, int dsize, char *routine)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   if (object->dsize < dsize)
     { if (object->dsize == 0)
@@ -564,7 +564,7 @@ static inline void allocate_tifd_data(TIFD *tifd, int dsize, char *routine)
     }
 }
 
-static inline TIFD *new_tifd(int tsize, int vsize, int dsize, char *routine)
+static  TIFD *new_tifd(int tsize, int vsize, int dsize, char *routine)
 { _TIFD *object;
 
   if (Free_TIFD_List == NULL)
@@ -585,7 +585,7 @@ static inline TIFD *new_tifd(int tsize, int vsize, int dsize, char *routine)
   return (&(object->tifd));
 }
 
-static inline TIFD *copy_tifd(TIFD *tifd)
+static  TIFD *copy_tifd(TIFD *tifd)
 { TIFD *copy = new_tifd(tifd_tsize(tifd),tifd_vsize(tifd),tifd_dsize(tifd),"Copy_Tiff_IFD");
   TIFD  temp = *copy;
   *copy = *tifd;
@@ -604,7 +604,7 @@ static inline TIFD *copy_tifd(TIFD *tifd)
 Tiff_IFD *Copy_Tiff_IFD(Tiff_IFD *tiff_ifd)
 { return ((Tiff_IFD *) copy_tifd((TIFD *) tiff_ifd)); }
 
-static inline void pack_tifd(TIFD *tifd)
+static  void pack_tifd(TIFD *tifd)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   if (object->tsize > tifd_tsize(tifd))
     { object->tsize = tifd_tsize(tifd);
@@ -641,7 +641,7 @@ static inline void pack_tifd(TIFD *tifd)
 void Pack_Tiff_IFD(Tiff_IFD *tiff_ifd)
 { pack_tifd(((TIFD *) tiff_ifd)); }
 
-static inline void free_tifd(TIFD *tifd)
+static  void free_tifd(TIFD *tifd)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   object->next = Free_TIFD_List;
   Free_TIFD_List = object;
@@ -651,7 +651,7 @@ static inline void free_tifd(TIFD *tifd)
 void Free_Tiff_IFD(Tiff_IFD *tiff_ifd)
 { free_tifd(((TIFD *) tiff_ifd)); }
 
-static inline void kill_tifd(TIFD *tifd)
+static  void kill_tifd(TIFD *tifd)
 { _TIFD *object  = (_TIFD *) (((char *) tifd) - TIFD_Offset);
   if (object->dsize != 0)
     free(tifd->data);
@@ -666,7 +666,7 @@ static inline void kill_tifd(TIFD *tifd)
 void Kill_Tiff_IFD(Tiff_IFD *tiff_ifd)
 { kill_tifd(((TIFD *) tiff_ifd)); }
 
-static inline void reset_tifd()
+static  void reset_tifd()
 { _TIFD *object;
   while (Free_TIFD_List != NULL)
     { object = Free_TIFD_List;

--- a/src/trace.c
+++ b/src/trace.c
@@ -95,13 +95,13 @@ void          initialize_paramater_ranges  (Line_Params *line, Interval *roff, I
 void breakme(void) {
 }
 
-static inline int outofbounds(int q, int cwidth, int cheight)
+static  int outofbounds(int q, int cwidth, int cheight)
 { int x = q%cwidth;
   int y = q/cwidth;
   return (x < 1 || x >= cwidth-1 ||y < 1 || y >= cheight-1);
 }
 
-inline int is_small_angle( float angle )
+ int is_small_angle( float angle )
   /* true iff angle is in [-pi/4,pi/4) or [3pi/4,5pi/4) */
 { static const float qpi = M_PI/4.0;
   static const float hpi = M_PI/2.0;
@@ -109,7 +109,7 @@ inline int is_small_angle( float angle )
   return  (n % 2) != 0;
 }
 
-inline int is_angle_leftward( float angle )
+ int is_angle_leftward( float angle )
   /* true iff angle is in left half plane */
 { //static const float qpi = M_PI/4.0;
   static const float hpi = M_PI/2.0;

--- a/src/traj.c
+++ b/src/traj.c
@@ -443,7 +443,7 @@ static int cmp_sort_segment_uid( const void* a, const void* b )
 }
 
 /*
-static inline double _cmp_sort_face_order__angle_wrt_face( Measurements *a )
+static  double _cmp_sort_face_order__angle_wrt_face( Measurements *a )
 { int ix = a->col_follicle_x,
       iy = a->col_follicle_y,
        v = atan2( a->data[iy] - a->face_y,
@@ -454,7 +454,7 @@ static inline double _cmp_sort_face_order__angle_wrt_face( Measurements *a )
 */
 
 
-static inline int _cmp_sort_face__ccw_test( Measurements *a, Measurements *b )
+static  int _cmp_sort_face__ccw_test( Measurements *a, Measurements *b )
 { int ix = a->col_follicle_x,
       iy = a->col_follicle_y;
   double ax = a->data[ix] - a->face_x,
@@ -466,7 +466,7 @@ static inline int _cmp_sort_face__ccw_test( Measurements *a, Measurements *b )
   return (v<0.0)?-1:((v>0.0)?1:0);
 }
 
-static inline int _cmp_sort_face__angle_wrt_face( Measurements *a, Measurements *b )
+static  int _cmp_sort_face__angle_wrt_face( Measurements *a, Measurements *b )
 { int ix = a->col_follicle_x,
       iy = a->col_follicle_y;
   double ax = a->data[ix] - a->face_x, // translate origin to face pos
@@ -558,7 +558,7 @@ void Sort_Measurements_Table_Time_State_Face( Measurements *table, int nrows )
 { qsort( table, nrows, sizeof(Measurements), cmp_sort_time_state_face_order );
 }
 
-inline double _diff(double a, double b)
+ double _diff(double a, double b)
 { double c = a-b;
   return c*c;
 }

--- a/src/utilities.p
+++ b/src/utilities.p
@@ -1862,7 +1862,7 @@ static void build_unit_table(Automaton *mach)
 
 // Add a match to the argp'th argument to unit def's list of matches
 
-static inline Candidate *add_match(Unit *def, int argp)
+static  Candidate *add_match(Unit *def, int argp)
 { Candidate *mat = (Candidate  *) Guarded_Malloc(sizeof(Candidate),"Process_Argument");
   mat->next  = def->clist;
   mat->argp  = argp;

--- a/src/water_shed.p
+++ b/src/water_shed.p
@@ -43,7 +43,7 @@ static int *get_chord(int area, char *routine)
   return (Array);
 }
 
-static inline int watershed_2d_ssize(Watershed_2D *part)
+static  int watershed_2d_ssize(Watershed_2D *part)
 { return (sizeof(int)*(part->nbasins+1)); }
 
 MANAGER -r Watershed_2D seeds:ssize labels^Image
@@ -67,7 +67,7 @@ static int chk_width;
 static int chk_height;
 static int chk_iscon4;
 
-static inline int *boundary_pixels_2d(int p)
+static  int *boundary_pixels_2d(int p)
 { static int bound[8];
   int x, xn, xp;
   int y, yn, yp;
@@ -537,7 +537,7 @@ Watershed_2D *Build_2D_Watershed(Image *frame, int iscon4)
  ****************************************************************************************/
 
 
-static inline int watershed_3d_ssize(Watershed_3D *part)
+static  int watershed_3d_ssize(Watershed_3D *part)
 { return (sizeof(int)*(part->nbasins+1)); }
 
 MANAGER -r Watershed_3D seeds:ssize labels^Stack
@@ -552,7 +552,7 @@ static int cvolume;
 static int chk_depth;
 static int chk_iscon6;
 
-static inline int *boundary_pixels_3d(int p)
+static  int *boundary_pixels_3d(int p)
 { static int bound[26];
   int x, xn, xp;
   int y, yn, yp;


### PR DESCRIPTION
This removes the keyword "inline" from every *.c,*.h, and *.p file, as discussed in https://github.com/nclack/whisk/issues/33 . This seems to be necessary to get it compiled with modern compilers.

I should say that I don't totally understand the effect of removing "inline", I just know that it works for me. In particular there is an idiom "#define inline _inline" in ffmpeg_adapt.h and compat.h which I don't understand. @nclack would you please review the changed version of those lines and let me know if you think the change is okay?